### PR TITLE
Correct section header formatting following HTML snippet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,34 @@
 version = 4
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "doxygen-bindgen"
 version = "0.1.2"
 dependencies = [
+ "pretty_assertions",
  "yap",
 ]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ description = "Converts Doxygen comments into Rustdoc markdown"
 
 [dependencies]
 yap = "0.12.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ pub fn transform(str: &str) -> Result<String, Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     #[test]
     fn basic() {
         const S: &str = "The FILE_BASIC_INFORMATION structure contains timestamps and basic attributes of a file.\n \\li If you specify a value of zero for any of the XxxTime members, the file system keeps a file's current value for that time.\n \\li If you specify a value of -1 for any of the XxxTime members, time stamp updates are disabled for I/O operations preformed on the file handle.\n\\li If you specify a value of -2 for any of the XxxTime members, time stamp updates are enabled for I/O operations preformed on the file handle.\n\\remarks To set the members of this structure, the caller must have FILE_WRITE_ATTRIBUTES access to the file.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,14 @@ fn skip_whitespace(toks: &mut impl Tokens<Item = char>) {
 /// Emits a section header if it's not already emitted.
 fn emit_section_header(output: &mut Vec<String>, header: &str) {
     if !output.iter().any(|line| line.trim() == header) {
+
+        // inspect previous token, transform single new line into two new lines
+        if let Some(last) = output.last_mut() {
+            if last == "\n" {
+                last.push('\n');
+            }
+        }
+
         output.push(header.to_owned());
         output.push("\n\n".to_owned());
     }
@@ -101,14 +109,21 @@ mod tests {
     #[test]
     fn with_sections() {
         const S: &str = " The NtDelayExecution routine suspends the current thread until the specified condition is met.\n\n @param Alertable The function returns when either the time-out period has elapsed or when the APC function is called.\n @param DelayInterval The time interval for which execution is to be suspended, in milliseconds.\n - A value of zero causes the thread to relinquish the remainder of its time slice to any other thread that is ready to run.\n - If there are no other threads ready to run, the function returns immediately, and the thread continues execution.\n - A value of INFINITE indicates that the suspension should not time out.\n @return NTSTATUS Successful or errant status. The return value is STATUS_USER_APC when Alertable is TRUE, and the function returned due to one or more I/O completion callback functions.\n @remarks Note that a ready thread is not guaranteed to run immediately. Consequently, the thread will not run until some arbitrary time after the sleep interval elapses,\n based upon the system \"tick\" frequency and the load factor from other processes.\n @see https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex";
-        const S_: &str = "The NtDelayExecution routine suspends the current thread until the specified condition is met.\n# Arguments\n\n* `Alertable` - The function returns when either the time-out period has elapsed or when the APC function is called.\n* `DelayInterval` - The time interval for which execution is to be suspended, in milliseconds.\n- A value of zero causes the thread to relinquish the remainder of its time slice to any other thread that is ready to run.\n- If there are no other threads ready to run, the function returns immediately, and the thread continues execution.\n- A value of INFINITE indicates that the suspension should not time out.\n# Returns\n\nNTSTATUS Successful or errant status. The return value is STATUS_USER_APC when Alertable is TRUE, and the function returned due to one or more I/O completion callback functions.\n> Note that a ready thread is not guaranteed to run immediately. Consequently, the thread will not run until some arbitrary time after the sleep interval elapses,\nbased upon the system \"tick\" frequency and the load factor from other processes.\n# See also\n\n> [https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex)";
+        const S_: &str = "The NtDelayExecution routine suspends the current thread until the specified condition is met.\n\n# Arguments\n\n* `Alertable` - The function returns when either the time-out period has elapsed or when the APC function is called.\n* `DelayInterval` - The time interval for which execution is to be suspended, in milliseconds.\n- A value of zero causes the thread to relinquish the remainder of its time slice to any other thread that is ready to run.\n- If there are no other threads ready to run, the function returns immediately, and the thread continues execution.\n- A value of INFINITE indicates that the suspension should not time out.\n\n# Returns\n\nNTSTATUS Successful or errant status. The return value is STATUS_USER_APC when Alertable is TRUE, and the function returned due to one or more I/O completion callback functions.\n> Note that a ready thread is not guaranteed to run immediately. Consequently, the thread will not run until some arbitrary time after the sleep interval elapses,\nbased upon the system \"tick\" frequency and the load factor from other processes.\n\n# See also\n\n> [https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex)";
         assert_eq!(crate::transform(S).unwrap(), S_);
     }
 
     #[test]
     fn with_attributes() {
         const S: &str = "Creates a new registry key or opens an existing one, and it associates the key with a transaction.\n\n@param[out] KeyHandle A pointer to a handle that receives the key handle.\n @param[in] DesiredAccess The access mask that specifies the desired access rights.\n@param[in] ObjectAttributes A pointer to an OBJECT_ATTRIBUTES structure that specifies the object attributes.\n@param[in] TitleIndex Reserved.\n@param[in, optional] Class A pointer to a UNICODE_STRING structure that specifies the class of the key.\n @param[in] CreateOptions The options to use when creating the key.\n@param[in] TransactionHandle A handle to the transaction.\n @param[out, optional] Disposition A pointer to a variable that receives the disposition value.\n@return NTSTATUS Successful or errant status.\n";
-        const S_: &str = "Creates a new registry key or opens an existing one, and it associates the key with a transaction.\n# Arguments\n\n* `KeyHandle` [out]  - A pointer to a handle that receives the key handle.\n* `DesiredAccess` [in]  - The access mask that specifies the desired access rights.\n* `ObjectAttributes` [in]  - A pointer to an OBJECT_ATTRIBUTES structure that specifies the object attributes.\n* `TitleIndex` [in]  - Reserved.\n* `Class` [in, optional]  - A pointer to a UNICODE_STRING structure that specifies the class of the key.\n* `CreateOptions` [in]  - The options to use when creating the key.\n* `TransactionHandle` [in]  - A handle to the transaction.\n* `Disposition` [out, optional]  - A pointer to a variable that receives the disposition value.\n# Returns\n\nNTSTATUS Successful or errant status.\n";
+        const S_: &str = "Creates a new registry key or opens an existing one, and it associates the key with a transaction.\n\n# Arguments\n\n* `KeyHandle` [out]  - A pointer to a handle that receives the key handle.\n* `DesiredAccess` [in]  - The access mask that specifies the desired access rights.\n* `ObjectAttributes` [in]  - A pointer to an OBJECT_ATTRIBUTES structure that specifies the object attributes.\n* `TitleIndex` [in]  - Reserved.\n* `Class` [in, optional]  - A pointer to a UNICODE_STRING structure that specifies the class of the key.\n* `CreateOptions` [in]  - The options to use when creating the key.\n* `TransactionHandle` [in]  - A handle to the transaction.\n* `Disposition` [out, optional]  - A pointer to a variable that receives the disposition value.\n\n# Returns\n\nNTSTATUS Successful or errant status.\n";
+        assert_eq!(crate::transform(S).unwrap(), S_);
+    }
+
+    #[test]
+    fn new_paragraph_after_html() {
+        const S: &str =  "Set encoding parameters to default values:\n<ul>\n<li>Lossless</li>\n<li>1 tile\n</li>\n<li>etc...</li>\n</ul>\n@param parameters Compression parameters";
+        const S_: &str = "Set encoding parameters to default values:\n<ul>\n<li>Lossless</li>\n<li>1 tile\n</li>\n<li>etc...</li>\n</ul>\n\n# Arguments\n\n* `parameters` - Compression parameters";
         assert_eq!(crate::transform(S).unwrap(), S_);
     }
 }


### PR DESCRIPTION
First of all, thank you very much for this crate! It greatly improved my latest maintenance efforts of the `openjpeg-sys` crate.

I stumbled upon this quirk, where section headers are not interpreted as Markdown if the line before the header is in HTML (the screenshot shows the problem). I believe that ensuring a paragraph break before the header would be the best way to fix this issue.

![](https://github.com/user-attachments/assets/49682a92-a9ad-4ccb-9d26-d60be6169dda)

Moreover, I used `pretty_assertions` to inspect the test outcomes and it proved very useful to me, so I included it here. Please let me know if you would rather keep it out of this PR.
